### PR TITLE
Add options for compiling without each of the libraries

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class BoostConan(ConanFile):
         "wave": [True, False]
     }
 
-    default_options = "shared=True", \
+    default_options = "shared=False", \
         "header_only=False", \
         "fPIC=False", \
         "python=False", \

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,67 +13,67 @@ class BoostConan(ConanFile):
         "shared": [True, False],
         "header_only": [True, False],
         "fPIC": [True, False],
-        "python": [True, False],
-        "atomic": [True, False],
-        "chrono": [True, False],
-        "container": [True, False],
-        "context": [True, False],
-        "coroutine": [True, False],
-        "coroutine2": [True, False],
-        "date_time": [True, False],
-        "exception": [True, False],
-        "filesystem": [True, False],
-        "graph": [True, False],
-        "graph_parallel": [True, False],
-        "iostreams": [True, False],
-        "locale": [True, False],
-        "log": [True, False],
-        "math": [True, False],
-        "mpi": [True, False],
-        "program_options": [True, False],
-        "random": [True, False],
-        "regex": [True, False],
-        "serialization": [True, False],
-        "signals": [True, False],
-        "system": [True, False],
-        "test": [True, False],
-        "thread": [True, False],
-        "timer": [True, False],
-        "type_erasure": [True, False],
-        "wave": [True, False]
+        "python": [True, False], # Note: this variable does not have the 'without_' prefix to keep the old shas
+        "without_atomic": [True, False],
+        "without_chrono": [True, False],
+        "without_container": [True, False],
+        "without_context": [True, False],
+        "without_coroutine": [True, False],
+        "without_coroutine2": [True, False],
+        "without_date_time": [True, False],
+        "without_exception": [True, False],
+        "without_filesystem": [True, False],
+        "without_graph": [True, False],
+        "without_graph_parallel": [True, False],
+        "without_iostreams": [True, False],
+        "without_locale": [True, False],
+        "without_log": [True, False],
+        "without_math": [True, False],
+        "without_mpi": [True, False],
+        "without_program_options": [True, False],
+        "without_random": [True, False],
+        "without_regex": [True, False],
+        "without_serialization": [True, False],
+        "without_signals": [True, False],
+        "without_system": [True, False],
+        "without_test": [True, False],
+        "without_thread": [True, False],
+        "without_timer": [True, False],
+        "without_type_erasure": [True, False],
+        "without_wave": [True, False]
     }
 
     default_options = "shared=False", \
         "header_only=False", \
         "fPIC=False", \
         "python=False", \
-        "atomic=True", \
-        "chrono=True", \
-        "container=True", \
-        "context=True", \
-        "coroutine=True", \
-        "coroutine2=True", \
-        "date_time=True", \
-        "exception=True", \
-        "filesystem=True", \
-        "graph=True", \
-        "graph_parallel=True", \
-        "iostreams=True", \
-        "locale=True", \
-        "log=True", \
-        "math=True", \
-        "mpi=True", \
-        "program_options=True", \
-        "random=True", \
-        "regex=True", \
-        "serialization=True", \
-        "signals=True", \
-        "system=True", \
-        "test=True", \
-        "thread=True", \
-        "timer=True", \
-        "type_erasure=True", \
-        "wave=True"
+        "without_atomic=False", \
+        "without_chrono=False", \
+        "without_container=False", \
+        "without_context=False", \
+        "without_coroutine=False", \
+        "without_coroutine2=False", \
+        "without_date_time=False", \
+        "without_exception=False", \
+        "without_filesystem=False", \
+        "without_graph=False", \
+        "without_graph_parallel=False", \
+        "without_iostreams=False", \
+        "without_locale=False", \
+        "without_log=False", \
+        "without_math=False", \
+        "without_mpi=False", \
+        "without_program_options=False", \
+        "without_random=False", \
+        "without_regex=False", \
+        "without_serialization=False", \
+        "without_signals=False", \
+        "without_system=False", \
+        "without_test=False", \
+        "without_thread=False", \
+        "without_timer=False", \
+        "without_type_erasure=False", \
+        "without_wave=False"
 
     url="https://github.com/lasote/conan-boost"
     exports = ["FindBoost.cmake"]
@@ -154,38 +154,37 @@ class BoostConan(ConanFile):
         flags.append("address-model=%s" % ("32" if self.settings.arch == "x86" else "64"))
 
         option_names = {
-            "--without-atomic": self.options.atomic,
-            "--without-chrono": self.options.chrono,
-            "--without-container": self.options.container,
-            "--without-coroutine": self.options.coroutine,
-            "--without-coroutine2": self.options.coroutine2,
-            "--without-date_time": self.options.date_time,
-            "--without-exception": self.options.exception,
-            "--without-filesystem": self.options.filesystem,
-            "--without-graph": self.options.graph,
-            "--without-graph_parallel": self.options.graph_parallel,
-            "--without-iostreams": self.options.iostreams,
-            "--without-locale": self.options.locale,
-            "--without-log": self.options.log,
-            "--without-math": self.options.math,
-            "--without-mpi": self.options.mpi,
-            "--without-program_options": self.options.program_options,
-            "--without-random": self.options.random,
-            "--without-regex": self.options.regex,
-            "--without-serialization": self.options.serialization,
-            "--without-signals": self.options.signals,
-            "--without-system": self.options.system,
-            "--without-test": self.options.test,
-            "--without-thread": self.options.thread,
-            "--without-timer": self.options.timer,
-            "--without-type_erasure": self.options.type_erasure,
-            "--without-wave": self.options.wave,
-            "--without-python": self.options.python
+            "--without-atomic": self.options.without_atomic,
+            "--without-chrono": self.options.without_chrono,
+            "--without-container": self.options.without_container,
+            "--without-coroutine": self.options.without_coroutine,
+            "--without-coroutine2": self.options.without_coroutine2,
+            "--without-date_time": self.options.without_date_time,
+            "--without-exception": self.options.without_exception,
+            "--without-filesystem": self.options.without_filesystem,
+            "--without-graph": self.options.without_graph,
+            "--without-graph_parallel": self.options.without_graph_parallel,
+            "--without-iostreams": self.options.without_iostreams,
+            "--without-locale": self.options.without_locale,
+            "--without-log": self.options.without_log,
+            "--without-math": self.options.without_math,
+            "--without-mpi": self.options.without_mpi,
+            "--without-program_options": self.options.without_program_options,
+            "--without-random": self.options.without_random,
+            "--without-regex": self.options.without_regex,
+            "--without-serialization": self.options.without_serialization,
+            "--without-signals": self.options.without_signals,
+            "--without-system": self.options.without_system,
+            "--without-test": self.options.without_test,
+            "--without-thread": self.options.without_thread,
+            "--without-timer": self.options.without_timer,
+            "--without-type_erasure": self.options.without_type_erasure,
+            "--without-wave": self.options.without_wave
         }
 
         for option_name, activated in option_names.iteritems():
             self.output.warn("%s --> %s" % (option_name, activated))
-            if not activated:
+            if activated:
                 flags.append(option_name)
 
         cxx_flags = []
@@ -224,11 +223,13 @@ class BoostConan(ConanFile):
         else:
             deps_options = ""
 
-        full_command = "cd %s && %s %s -j%s --abbreviate-paths %s" % (
+        without_python = "--without-python" if not self.options.python else ""
+        full_command = "cd %s && %s %s -j%s --abbreviate-paths %s %s" % (
             self.FOLDER_NAME,
             command,
             b2_flags,
             tools.cpu_count(),
+            without_python,
             deps_options)
         self.output.warn(full_command)
         self.run(full_command)#, output=False)

--- a/conanfile.py
+++ b/conanfile.py
@@ -183,7 +183,6 @@ class BoostConan(ConanFile):
         }
 
         for option_name, activated in option_names.iteritems():
-            self.output.warn("%s --> %s" % (option_name, activated))
             if activated:
                 flags.append(option_name)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,15 +3,78 @@ from conans import tools
 import platform, os, sys
 
 
-
 class BoostConan(ConanFile):
     name = "Boost"
     version = "1.60.0"
     settings = "os", "arch", "compiler", "build_type"
     FOLDER_NAME = "boost_%s" % version.replace(".", "_")
     # The current python option requires the package to be built locally, to find default Python implementation
-    options = {"shared": [True, False], "header_only": [True, False], "fPIC": [True, False], "python": [True, False]}
-    default_options = "shared=False", "header_only=False", "fPIC=False", "python=False"
+    options = {
+        "shared": [True, False],
+        "header_only": [True, False],
+        "fPIC": [True, False],
+        "python": [True, False],
+        "atomic": [True, False],
+        "chrono": [True, False],
+        "container": [True, False],
+        "context": [True, False],
+        "coroutine": [True, False],
+        "coroutine2": [True, False],
+        "date_time": [True, False],
+        "exception": [True, False],
+        "filesystem": [True, False],
+        "graph": [True, False],
+        "graph_parallel": [True, False],
+        "iostreams": [True, False],
+        "locale": [True, False],
+        "log": [True, False],
+        "math": [True, False],
+        "mpi": [True, False],
+        "program_options": [True, False],
+        "random": [True, False],
+        "regex": [True, False],
+        "serialization": [True, False],
+        "signals": [True, False],
+        "system": [True, False],
+        "test": [True, False],
+        "thread": [True, False],
+        "timer": [True, False],
+        "type_erasure": [True, False],
+        "wave": [True, False]
+    }
+
+    default_options = "shared=True", \
+        "header_only=False", \
+        "fPIC=False", \
+        "python=False", \
+        "atomic=True", \
+        "chrono=True", \
+        "container=True", \
+        "context=True", \
+        "coroutine=True", \
+        "coroutine2=True", \
+        "date_time=True", \
+        "exception=True", \
+        "filesystem=True", \
+        "graph=True", \
+        "graph_parallel=True", \
+        "iostreams=True", \
+        "locale=True", \
+        "log=True", \
+        "math=True", \
+        "mpi=True", \
+        "program_options=True", \
+        "random=True", \
+        "regex=True", \
+        "serialization=True", \
+        "signals=True", \
+        "system=True", \
+        "test=True", \
+        "thread=True", \
+        "timer=True", \
+        "type_erasure=True", \
+        "wave=True"
+
     url="https://github.com/lasote/conan-boost"
     exports = ["FindBoost.cmake"]
     license="Boost Software License - Version 1.0. http://www.boost.org/LICENSE_1_0.txt"
@@ -90,6 +153,40 @@ class BoostConan(ConanFile):
         flags.append("variant=%s" % str(self.settings.build_type).lower())
         flags.append("address-model=%s" % ("32" if self.settings.arch == "x86" else "64"))
 
+        option_names = {
+            "--without-atomic": self.options.atomic,
+            "--without-chrono": self.options.chrono,
+            "--without-container": self.options.container,
+            "--without-coroutine": self.options.coroutine,
+            "--without-coroutine2": self.options.coroutine2,
+            "--without-date_time": self.options.date_time,
+            "--without-exception": self.options.exception,
+            "--without-filesystem": self.options.filesystem,
+            "--without-graph": self.options.graph,
+            "--without-graph_parallel": self.options.graph_parallel,
+            "--without-iostreams": self.options.iostreams,
+            "--without-locale": self.options.locale,
+            "--without-log": self.options.log,
+            "--without-math": self.options.math,
+            "--without-mpi": self.options.mpi,
+            "--without-program_options": self.options.program_options,
+            "--without-random": self.options.random,
+            "--without-regex": self.options.regex,
+            "--without-serialization": self.options.serialization,
+            "--without-signals": self.options.signals,
+            "--without-system": self.options.system,
+            "--without-test": self.options.test,
+            "--without-thread": self.options.thread,
+            "--without-timer": self.options.timer,
+            "--without-type_erasure": self.options.type_erasure,
+            "--without-wave": self.options.wave,
+            "--without-python": self.options.python
+        }
+
+        for option_name, activated in option_names.iteritems():
+            self.output.warn("%s --> %s" % (option_name, activated))
+            if not activated:
+                flags.append(option_name)
 
         cxx_flags = []
         # fPIC DEFINITION
@@ -127,8 +224,7 @@ class BoostConan(ConanFile):
         else:
             deps_options = ""
 
-        without_python = "--without-python" if not self.options.python else ""
-        full_command = "cd %s && %s %s -j4 --abbreviate-paths %s %s" % (self.FOLDER_NAME, command, b2_flags, without_python, deps_options)
+        full_command = "cd %s && %s %s -j4 --abbreviate-paths %s" % (self.FOLDER_NAME, command, b2_flags, deps_options)
         self.output.warn(full_command)
         self.run(full_command)#, output=False)
 


### PR DESCRIPTION
After the discussion we had in the PR #23, I have created this new one with the implementation in which we agreed. Now we will have one option per library indicating if the library will be compiled or not (all of them are defaulted to True, except **python**). 
