### PR TITLE
Fix for python 3. Call items() in dict

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -183,7 +183,7 @@ class BoostConan(ConanFile):
             "--without-wave": self.options.without_wave
         }
 
-        for option_name, activated in option_names.iteritems():
+        for option_name, activated in option_names.items():
             if activated:
                 flags.append(option_name)
 


### PR DESCRIPTION
I suppose that overhead of `.items()` call in Python 2 can be affordable given compile time for Boost libraries.