### PR TITLE
Support builds on Python 3

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -183,7 +183,7 @@ class BoostConan(ConanFile):
             "--without-wave": self.options.without_wave
         }
 
-        for option_name, activated in option_names.iteritems():
+        for option_name, activated in option_names.items():
             if activated:
                 flags.append(option_name)
 


### PR DESCRIPTION
Using `dict.items()` instead of `dict.iteritems()` supports builds on both Python 2 and Python 3 without dependency on `six`.