### PR TITLE
Add missing travis pages for apple-clang 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,22 @@ matrix:
          osx_image: xcode8 # apple-clang 8
          language: generic
          env: CONAN_CURRENT_PAGE=4
+       - os: osx
+         osx_image: xcode8 # apple-clang 8
+         language: generic
+         env: CONAN_CURRENT_PAGE=5
+       - os: osx
+         osx_image: xcode8 # apple-clang 8
+         language: generic
+         env: CONAN_CURRENT_PAGE=6
+       - os: osx
+         osx_image: xcode8 # apple-clang 8
+         language: generic
+         env: CONAN_CURRENT_PAGE=7
+       - os: osx
+         osx_image: xcode8 # apple-clang 8
+         language: generic
+         env: CONAN_CURRENT_PAGE=8
 
        - os: osx
          osx_image: xcode7.3 # apple-clang 7.0


### PR DESCRIPTION
Hi! I noticed that there are no x86_64 binaries for macOS/apple-clang 8, so I'm adding them to CI here.