### PR TITLE
Fix to without_* rules under VS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -316,9 +316,8 @@ class BoostConan(ConanFile):
             suffix = "vc%d-%s%s-%s" %  (visual_version, runtime, abi_tags, version)
             prefix = "lib" if not self.options.shared else ""
 
-
             win_libs.extend(["%sboost_%s-%s" % (prefix, lib, suffix) for lib in libs if lib not in ["exception", "test_exec_monitor"]])
-            win_libs.extend(["libboost_exception-%s" % suffix, "libboost_test_exec_monitor-%s" % suffix])
+            win_libs.extend(["libboost_%s-%s" % (lib, suffix) for lib in libs if lib in ["exception", "test_exec_monitor"]])
 
             #self.output.warn("EXPORTED BOOST LIBRARIES: %s" % win_libs)
             self.cpp_info.libs.extend(win_libs)

--- a/conanfile.py
+++ b/conanfile.py
@@ -288,8 +288,8 @@ class BoostConan(ConanFile):
             if option.startswith('without_') and getattr(self.options, option):
                 lib_name = option[8:]
                 # Check for substring matches with libraries, and remove if appropriate
-                for l in filter(lambda x: x.find(lib_name) >= 0, libs):
-                    libs.remove(l)
+                libs = [l for l in libs if not lib_name in l]
+
         # We need a direct rule for boost_prg_exec_monitor, which is constructed
         # when without_test is NOT set (but is not a direct substring match)
         if self.options["without_test"]:


### PR DESCRIPTION
Currently there are some errors when using the `without_*` options with Visual Studio, with libraries that we are not building still being included in the generated `conanbuildinfo.props` file. This means that if we specify that we don't want to build particular libraries we will have to do some manual editing of the generated property file in order to get things to link.

This commit makes two changes:

1. Commit cfdb9216fadd64c3318dafe6cfbae0bb09d30d93 prevents boost libraries with non-trivial naming conventions (e.g. `math_c99`, `math_c99f`, `math_c99l`, ...) form being included when they weren't built. I've done this using substring matches (plus an exception for `prg_exec_monitor`) whcih is _OK_ for this, but not ideal.

2. Commit 4140b6c96aaef279d1d5ab6a7e047d1ecc68c9fc corrects the hard-coded rule for linking the static versions of the `exception` and `test_exec_monitor` libraries, only including these when it's actually appropriate.