### PR TITLE
Fixes for MinGW compilation under Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,32 @@ environment:
           CONAN_VISUAL_VERSIONS: 12
           CONAN_CURRENT_PAGE: 4
 
+        - MINGW_CONFIGURATIONS: "6.3@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 1
+        - MINGW_CONFIGURATIONS: "6.3@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 2
+        - MINGW_CONFIGURATIONS: "6.3@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 3
+        - MINGW_CONFIGURATIONS: "6.3@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 4
+
+        - MINGW_CONFIGURATIONS: "7.1@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 1
+        - MINGW_CONFIGURATIONS: "7.1@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 2
+        - MINGW_CONFIGURATIONS: "7.1@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 3
+        - MINGW_CONFIGURATIONS: "7.1@x86_64@seh@posix"
+          CONAN_BASH_PATH: "c:\\msys64\\usr\\bin\\bash"
+          CONAN_CURRENT_PAGE: 4
+
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade

--- a/conanfile.py
+++ b/conanfile.py
@@ -166,6 +166,9 @@ class BoostConan(ConanFile):
             # The NOT windows check is necessary to exclude MinGW:
             flags.append("toolset=%s-%s" % (self.settings.compiler,
                                             str(self.settings.compiler.version)[0]))
+        elif self.settings.os == "Windows" and self.settings.compiler == "gcc":
+            # For MinGW and GCC we need to provide only compiler name
+            flags.append("toolset=%s" % (self.settings.compiler))
         elif str(self.settings.compiler) in ["clang", "gcc"]:
             # For GCC < v5 and Clang we need to provide the entire version string
             flags.append("toolset=%s-%s" % (self.settings.compiler,
@@ -251,10 +254,11 @@ class BoostConan(ConanFile):
 
         flags = []
         if self.settings.os == "Windows" and self.settings.compiler == "gcc":
-            command += " mingw"
+            command += " gcc"
             flags.append("--layout=system")
 
         try:
+            print("cd %s && %s" % (self.FOLDER_NAME, command))
             self.run("cd %s && %s" % (self.FOLDER_NAME, command))
         except:
             self.run("cd %s && type bootstrap.log" % self.FOLDER_NAME

--- a/conanfile.py
+++ b/conanfile.py
@@ -258,7 +258,6 @@ class BoostConan(ConanFile):
             flags.append("--layout=system")
 
         try:
-            print("cd %s && %s" % (self.FOLDER_NAME, command))
             self.run("cd %s && %s" % (self.FOLDER_NAME, command))
         except:
             self.run("cd %s && type bootstrap.log" % self.FOLDER_NAME


### PR DESCRIPTION
Under Windows using MinGW compilation fails (using GCC 7.2.0). It's due to:

1. Bootstrap.bat does not know option mingw, gcc should be passed (http://www.boost.org/doc/libs/1_65_1/more/getting_started/windows.html)

2. Executable b2 compiling boost under windows doesn't understand toolset option set to gcc-"VERSION", there should be alone "gcc" passed
