### PR TITLE
Feature/update to boost 1.65.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Conan.io Boost package](https://img.shields.io/badge/conan.io-Boost%2F1.65.1-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](http://www.conan.io/source/Boost/1.65.1/lasote/stable) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/lasote/conan-boost?svg=true&branch=release/1.64)](https://ci.appveyor.com/project/lasote/conan-boost) [![Travis Build Status](https://api.travis-ci.org/lasote/conan-boost.svg?branch=release/1.65.1)](https://travis-ci.org/lasote/conan-boost)
+[![Conan.io Boost package](https://img.shields.io/badge/conan.io-Boost%2F1.65.1-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](http://www.conan.io/source/Boost/1.65.1/lasote/testing) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/lasote/conan-boost?svg=true&branch=release/1.64)](https://ci.appveyor.com/project/lasote/conan-boost) [![Travis Build Status](https://api.travis-ci.org/lasote/conan-boost.svg?branch=release/1.65.1)](https://travis-ci.org/lasote/conan-boost)
 
 # conan-boost
 
@@ -12,14 +12,14 @@ The packages generated with this **conanfile** can be found on [bintray](https:/
 
 ### Basic setup
 
-    $ conan install Boost/1.65.1@conan/stable
+    $ conan install Boost/1.65.1@conan/testing
 
 ### Project setup
 
 If you handle multiple dependencies in your project is better to add a *conanfile.txt*
 
     [requires]
-    Boost/1.65.1@conan/stable
+    Boost/1.65.1@conan/testing
 
     [options]
     Boost:shared=true # false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Conan.io Boost package](https://img.shields.io/badge/conan.io-Boost%2F1.64.0-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](http://www.conan.io/source/Boost/1.64.0/lasote/stable) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/lasote/conan-boost?svg=true&branch=release/1.64)](https://ci.appveyor.com/project/lasote/conan-boost) [![Travis Build Status](https://api.travis-ci.org/lasote/conan-boost.svg?branch=release/1.64.0)](https://travis-ci.org/lasote/conan-boost)
+[![Conan.io Boost package](https://img.shields.io/badge/conan.io-Boost%2F1.65.1-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](http://www.conan.io/source/Boost/1.65.1/lasote/stable) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/lasote/conan-boost?svg=true&branch=release/1.64)](https://ci.appveyor.com/project/lasote/conan-boost) [![Travis Build Status](https://api.travis-ci.org/lasote/conan-boost.svg?branch=release/1.65.1)](https://travis-ci.org/lasote/conan-boost)
 
 # conan-boost
 
@@ -12,14 +12,14 @@ The packages generated with this **conanfile** can be found on [bintray](https:/
 
 ### Basic setup
 
-    $ conan install Boost/1.64.0@conan/stable
+    $ conan install Boost/1.65.1@conan/stable
 
 ### Project setup
 
 If you handle multiple dependencies in your project is better to add a *conanfile.txt*
 
     [requires]
-    Boost/1.64.0@conan/stable
+    Boost/1.65.1@conan/stable
 
     [options]
     Boost:shared=true # false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "Boost/1.64.0"
+    CONAN_REFERENCE: "Boost/1.65.1"
     CONAN_USERNAME: "conan"
     CONAN_LOGIN_USERNAME: "lasote"
     CONAN_CHANNEL: "testing"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,7 +95,7 @@ install:
   - pip.exe install conan_package_tools
   - conan user # It creates the conan data directory
   - conan install zlib/1.2.11@conan/stable
-  - conan install bzip2/1.0.6@conan/stable
+  - conan install bzip2/1.0.6@conan/stable --build bzip2
 
 test_script:
   - python build.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,7 +95,7 @@ install:
   - pip.exe install conan_package_tools
   - conan user # It creates the conan data directory
   - conan install zlib/1.2.11@conan/stable
-  - conan install bzip2/1.0.6@conan/stable --build bzip2
+  - conan install bzip2/1.0.6@conan/stable
 
 test_script:
   - python build.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,8 @@ install:
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools
   - conan user # It creates the conan data directory
+  - conan install zlib/1.2.11@conan/stable
+  - conan install bzip2/1.0.6@conan/stable
 
 test_script:
   - python build.py

--- a/conanfile.py
+++ b/conanfile.py
@@ -113,10 +113,10 @@ class BoostConan(ConanFile):
             self.options.remove("python")
 
         if not self.options.without_iostreams and not self.options.header_only:
-            self.requires("bzip2/1.0.6@conan/stable")
+            self.requires("bzip2/1.0.6@conan/testing")
             self.options["bzip2/1.0.6"].shared = self.options.shared
             
-            self.requires("zlib/1.2.11@conan/stable")
+            self.requires("zlib/1.2.11@conan/testing")
             self.options["zlib"].shared = self.options.shared
 
     def package_id(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os, sys
 
 
 class BoostConan(ConanFile):
-    name = "boost"
+    name = "Boost"
     version = "1.65.1"
     settings = "os", "arch", "compiler", "build_type"
     FOLDER_NAME = "boost_%s" % version.replace(".", "_")

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,8 +17,6 @@ class BoostConan(ConanFile):
         "python": [True, False],  # Note: this variable does not have the 'without_' prefix to keep
         # the old shas
         "without_atomic": [True, False],
-        #"without_beast": [True, False], # New in 1.66.0
-        #"without_callable_traits": [True, False], # New in 1.66.0
         "without_chrono": [True, False],
         "without_container": [True, False],
         "without_context": [True, False],
@@ -35,7 +33,6 @@ class BoostConan(ConanFile):
         "without_log": [True, False],
         "without_math": [True, False],
         "without_metaparse": [True, False],
-        #"without_mp11": [True, False], # New in 1.66.0
         "without_mpi": [True, False],
         "without_poly_collection": [True, False], # New in 1.65.0
         "without_program_options": [True, False],
@@ -116,12 +113,10 @@ class BoostConan(ConanFile):
             self.options.remove("python")
 
         if not self.options.without_iostreams and not self.options.header_only:
-            #self.requires("bzip2/1.0.6@%s/%s" % ("kwallner", "testing"))
             self.requires("bzip2/1.0.6@%s/%s" % (self.user, self.channel))
             self.options["bzip2/1.0.6"].shared = self.options.shared
             
-            #self.requires("zlib/1.2.11@%s/%s" % ("kwallner", "testing"))
-            self.requires("zlib/1.2.11@%s/%s" % (self.user, self.channel))
+           self.requires("zlib/1.2.11@%s/%s" % (self.user, self.channel))
             self.options["zlib"].shared = self.options.shared
 
     def package_id(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -137,7 +137,7 @@ class BoostConan(ConanFile):
         os.unlink(zip_name)
         
         self.output.info("Patching file %s..." % "msvc.jam")
-        tools.patch(patch_file="msvc.jam-1.65.1.patch")
+        tools.patch(patch_file="patches/msvc.jam-1.65.1.patch")
 
     def build(self):
         if self.options.header_only:

--- a/conanfile.py
+++ b/conanfile.py
@@ -113,10 +113,10 @@ class BoostConan(ConanFile):
             self.options.remove("python")
 
         if not self.options.without_iostreams and not self.options.header_only:
-            self.requires("bzip2/1.0.6@%s/%s" % (self.user, self.channel))
+            self.requires("bzip2/1.0.6@conan/stable")
             self.options["bzip2/1.0.6"].shared = self.options.shared
             
-           self.requires("zlib/1.2.11@%s/%s" % (self.user, self.channel))
+            self.requires("zlib/1.2.11@conan/stable")
             self.options["zlib"].shared = self.options.shared
 
     def package_id(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -113,10 +113,10 @@ class BoostConan(ConanFile):
             self.options.remove("python")
 
         if not self.options.without_iostreams and not self.options.header_only:
-            self.requires("bzip2/1.0.6@conan/testing")
+            self.requires("bzip2/1.0.6@conan/stable")
             self.options["bzip2/1.0.6"].shared = self.options.shared
             
-            self.requires("zlib/1.2.11@conan/testing")
+            self.requires("zlib/1.2.11@conan/stable")
             self.options["zlib"].shared = self.options.shared
 
     def package_id(self):

--- a/patches/msvc.jam-1.65.1.patch
+++ b/patches/msvc.jam-1.65.1.patch
@@ -1,0 +1,55 @@
+diff -r -u boost_1_65_1.orig/tools/build/src/tools/msvc.jam boost_1_65_1/tools/build/src/tools/msvc.jam
+--- boost_1_65_1.orig/tools/build/src/tools/msvc.jam	2017-09-02 11:56:19.000000000 +0200
++++ boost_1_65_1/tools/build/src/tools/msvc.jam	2017-04-17 04:22:26.000000000 +0200
+@@ -1250,39 +1250,10 @@
+     }
+     else
+     {
+-        # try to use vswhere
+-        local pseudo_env_VS150 ;
+-        if $(version) = 14.1 || $(version) = "default"
+-        {
+-            local req = "-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64" ;
+-            local prop = "-property installationPath" ;
+-            local limit = "-version \"[15.0,16.0)\"" ;
+-            local root = [ os.environ "ProgramFiles(x86)" ] ;
+-            if ( ! $(root) )
+-            {
+-                root = [ os.environ "ProgramFiles" ] ;
+-            }
+-            local vswhere = "$(root)\\Microsoft Visual Studio\\Installer\\vswhere.exe" ;
+-            if ( [ path.exists $(vswhere) ] )
+-            {
+-                local vmwhere_cmd = "\"$(vswhere)\" -latest -products * $(req) $(prop) $(limit)" ;
+-                local shell_ret = [ SPLIT_BY_CHARACTERS [ SHELL $(vmwhere_cmd) ] : "\n" ] ;
+-                pseudo_env_VS150 = [ path.native [ path.join $(shell_ret) "\\Common7\\Tools" ] ] ;
+-            }
+-        }
+-
+-        # Check environment or previous path_VS150
++        # Check environment.
+         for local env in $(.version-$(version)-env)
+         {
+-            local env-path ;
+-            if ( $(pseudo_env_VS150) && [ path.exists $(pseudo_env_VS150) ] )
+-            {
+-                env-path = $(pseudo_env_VS150) ;
+-            }
+-            else
+-            {
+-                env-path = [ os.environ $(env) ] ;
+-            }
++            local env-path = [ os.environ $(env) ] ;
+             if $(env-path) && $(.version-$(version)-path)
+             {
+                 for local bin-path in $(.version-$(version)-path)
+@@ -1698,7 +1669,8 @@
+ .version-7.1toolkit-path    = "Microsoft Visual C++ Toolkit 2003/bin" ;
+ .version-7.1toolkit-env     = VCToolkitInstallDir ;
+ # Visual Studio 2017 doesn't use a registry at all. And the suggested methods
+-# of discovery involve having a compiled program. So as a fallback we search
++# of discovery involve having a compiled program. We can't do that as it would
++# make for a recursive discovery and build dependency cycle. So we search
+ # paths for VS2017 (aka msvc >= 14.1).
+ .version-14.1-path =
+     "../../VC/Tools/MSVC/*/bin/Host*/*"


### PR DESCRIPTION
Branch contains changes to upate boost to 1.65.1

Summary of changes:
* Version-strings updated from 1.64.0 to 1.65.1
* Added options for new libraries (poly_collection, stacktrace)
* Patch for VS-compiler detection (Is broken in 1.65.1. This is just a backport to 1.64.0)
* Changed usage of bzip2: Bzip is now activated for all platforms (if iostream is enabled)
* Enabling of zlib/bzip2 is done using flags to b2 ("patch_project_jam" was removed)
* Changed channel naming from stable to testing

Tests done:
* Build done with "Visual Studio 2015 x64"
* Using it (cmake/compile/link) seem to work (as before)