### PR TITLE
Minimal support for cross-compiling for ARM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 *.pyc
+.idea/

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,9 +5,10 @@ import os, sys
 
 class BoostConan(ConanFile):
     name = "Boost"
-    version = "1.64.0"
+    version = "1.64.0+1"
+    boost_version = version.split('+')[0]
     settings = "os", "arch", "compiler", "build_type"
-    FOLDER_NAME = "boost_%s" % version.replace(".", "_")
+    FOLDER_NAME = "boost_%s" % boost_version.replace(".", "_")
     # The current python option requires the package to be built locally, to find default Python
     # implementation
     options = {
@@ -120,7 +121,7 @@ class BoostConan(ConanFile):
 
     def source(self):
         zip_name = "%s.zip" % self.FOLDER_NAME if sys.platform == "win32" else "%s.tar.gz" % self.FOLDER_NAME
-        url = "http://sourceforge.net/projects/boost/files/boost/%s/%s/download" % (self.version, zip_name)
+        url = "http://sourceforge.net/projects/boost/files/boost/%s/%s/download" % (self.boost_version, zip_name)
         self.output.info("Downloading %s..." % url)
         tools.download(url, zip_name)
         tools.unzip(zip_name)

--- a/conanfile.py
+++ b/conanfile.py
@@ -169,12 +169,16 @@ class BoostConan(ConanFile):
                                                       'compiler)'
             cross_compiler = tools.which(os.environ['CXX'])
             jam_filepath = os.path.join(self.source_folder, self.FOLDER_NAME, 'project-config.jam')
-            with open(jam_filepath, 'a') as jam_file:
-                jam_file.write('\nusing {0} : {1} : {2} ;'.format(
+            with open(jam_filepath, 'r+') as jam_file:
+                # Have to add it to the beginning fo the file or else Boost will try to load its own "gcc" toolset
+                # and potentially fail
+                original_content = jam_file.read()
+                jam_file.seek(0, 0)
+                jam_file.write('using {0} : {1} : {2} ;\n'.format(
                     self.settings.get_safe('compiler'),
                     architecture,
                     cross_compiler
-                ))
+                ) + original_content)
             flags.append('toolset={0}-{1}'.format(self.settings.get_safe('compiler'), architecture))
             flags.append('architecture=' + 'arm' if architecture.startswith('arm') else architecture)
             flags.append('address-model=32')  # Let's just assume it's 32-bit... 64-bit is pretty rare outside of x86_64

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,41 +1,47 @@
 PROJECT(MyHello)
 cmake_minimum_required(VERSION 2.8)
+enable_testing()
 
 set(Boost_DEBUG 1)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 
 CONAN_BASIC_SETUP()
 
+set(TEST_ARGS 123 234)
+
 IF(NOT HEADER_ONLY)
 	if(WITH_PYTHON)
-		find_package(Boost COMPONENTS regex python)
+		find_package(Boost COMPONENTS regex python REQUIRED)
 	else()
-		find_package(Boost COMPONENTS regex)
+		find_package(Boost COMPONENTS regex REQUIRED)
 	endif()
 	
-	IF(Boost_FOUND)
-	    include_directories(${Boost_INCLUDE_DIRS})
-	    ADD_EXECUTABLE(lambda lambda.cpp)
-	    ADD_EXECUTABLE(regex_exe regex.cpp)
-	    TARGET_LINK_LIBRARIES(regex_exe ${Boost_LIBRARIES})
-		if(WITH_PYTHON)
-			add_library(hello_ext SHARED python.cpp)
-			if(WIN32)
-				set_target_properties(hello_ext PROPERTIES SUFFIX ".pyd")
-				target_include_directories(hello_ext PRIVATE C:/Python27/include)
-				target_link_libraries(hello_ext C:/Python27/libs/python27.lib ${CONAN_LIBS})
-			endif()
-		endif()
-	ELSE()
-	    MESSAGE(FATAL_ERROR "ERROR! BOOST NOT FOUND!")
-	ENDIF()
+    include_directories(${Boost_INCLUDE_DIRS})
+    ADD_EXECUTABLE(lambda lambda.cpp)
+    ADD_EXECUTABLE(regex_exe regex.cpp)
+    TARGET_LINK_LIBRARIES(regex_exe ${Boost_LIBRARIES})
+    if(WITH_PYTHON)
+        add_library(hello_ext SHARED python.cpp)
+        if(WIN32)
+            set_target_properties(hello_ext PROPERTIES SUFFIX ".pyd")
+            target_include_directories(hello_ext PRIVATE C:/Python27/include)
+            target_link_libraries(hello_ext C:/Python27/libs/python27.lib ${CONAN_LIBS})
+        endif()
+    endif()
+
+    ADD_TEST(NAME TestRegex
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} "$<TARGET_FILE:regex_exe>")
 ELSE()
 	ADD_EXECUTABLE(lambda lambda.cpp)
 ENDIF()
+ADD_TEST(NAME TestLambda
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} "$<TARGET_FILE:lambda>" ${TEST_ARGS})
 
 
 IF(NOT HEADER_ONLY)
     # Test a different exe linking with the CONAN_LIBS to actually test the package_info
     ADD_EXECUTABLE(newregex regex.cpp)
     TARGET_LINK_LIBRARIES(newregex ${CONAN_LIBS})
+    ADD_TEST(NAME TestRegexNew
+            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} "$<TARGET_FILE:newregex>" ${TEST_ARGS})
 ENDIF()

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -28,7 +28,7 @@ class DefaultNameConan(ConanFile):
         self.copy(pattern="*.dylib", dst="bin", src="lib")
         
     def test(self):        
-        data_file = os.path.join(self.conanfile_directory, "data.txt")
+        data_file = os.path.join(self.source_folder, "data.txt")
         self.run("cd bin && .%slambda < %s" % (os.sep, data_file))
         if not self.options["Boost"].header_only:
             self.run("cd bin && .%sregex_exe < %s" % (os.sep, data_file))

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -28,12 +28,9 @@ class DefaultNameConan(ConanFile):
         self.copy(pattern="*.dylib", dst="bin", src="lib")
         
     def test(self):        
-        data_file = os.path.join(self.source_folder, "data.txt")
-        self.run("cd bin && .%slambda < %s" % (os.sep, data_file))
-        if not self.options["Boost"].header_only:
-            self.run("cd bin && .%sregex_exe < %s" % (os.sep, data_file))
-            if self.options["Boost"].python:
-                os.chdir("bin")
-                sys.path.append(".")
-                import hello_ext
-                hello_ext.greet()
+        self.run('ctest --output-on-error')
+        if self.options["Boost"].python:
+            os.chdir("bin")
+            sys.path.append(".")
+            import hello_ext
+            hello_ext.greet()

--- a/test_package/lambda.cpp
+++ b/test_package/lambda.cpp
@@ -1,13 +1,15 @@
 #include <boost/lambda/lambda.hpp>
 #include <iostream>
-#include <iterator>
-#include <algorithm>
 
-int main()
+int main(int argc, const char * const argv[])
 {
     using namespace boost::lambda;
-    typedef std::istream_iterator<int> in;
 
-    std::for_each(
-        in(std::cin), in(), std::cout << (_1 * 3) << " " );
+    std::vector<int> values;
+    for (int i = 1; i < argc; ++i)
+        values.push_back(atoi(argv[i]));
+
+    std::for_each(values.begin(), values.end(), std::cout << _1 * 3 << " " );
+
+    return 0;
 }

--- a/test_package/regex.cpp
+++ b/test_package/regex.cpp
@@ -1,15 +1,14 @@
 #include <boost/regex.hpp>
 #include <iostream>
-#include <string>
 
-int main()
+int main(int argc, const char * const argv[])
 {
     std::string line;
     boost::regex pat( "^Subject: (Re: |Aw: )*(.*)" );
 
-    while (std::cin)
-    {
-        std::getline(std::cin, line);
+    std::vector<int> values;
+    for (int i = 1; i < argc; ++i) {
+        const std::string word(argv[i]);
         boost::smatch matches;
         if (boost::regex_match(line, matches, pat))
             std::cout << matches[2] << std::endl;


### PR DESCRIPTION
Previously, the recipe assumed that we were compiling for either x86 or x86_64. There's a lot more logic that needs to go into this to support all the different ABIs and binary formats, but this was at least a start that should support most ARM platforms.