### PR TITLE
Fixing out of bound error cpp_info.libs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -298,7 +298,7 @@ class BoostConan(ConanFile):
     def package_info(self):
         gen_libs = tools.collect_libs(self)
 
-        self.cpp_info.libs = [None for _ in range(len(gen_libs))]
+        self.cpp_info.libs = [None for _ in range(len(lib_list))]
 
         # The order is important, reorder following the lib_list order
         missing_order_info = []


### PR DESCRIPTION
308: pos refers to the position in lib_list so cpp_info.libs needs to be at least this length.

This will leave a lot of None, but they should disappear. Otherwise a tmp list is needed and then extend that onto cpp_info.libs