### PR TITLE
Removed io_stream as for bzip and zlib

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,5 @@
+import shutil
+
 from conans import ConanFile
 from conans import tools
 import os
@@ -42,7 +44,7 @@ class BoostConan(ConanFile):
             self.options.remove("fPIC")
 
     def configure(self):
-        if not self.options.without_iostreams and not self.options.header_only:
+        if not self.options.header_only:
             self.requires("bzip2/1.0.6@conan/stable")
             self.options["bzip2"].shared = False
             


### PR DESCRIPTION
If io_stream is the only module that uses bzip and zlib then this should not be merged. If the other modules needs it then this should be merged